### PR TITLE
move position of attenuator setting dimension

### DIFF
--- a/apres/__init__.py
+++ b/apres/__init__.py
@@ -198,10 +198,10 @@ class ApRESBurst(object):
                 elif flatten.lower() == 'unity':
                     if m > 1:
                         self.data_dim_keys.append(key)
-                        data_shape.append(m)
+                        data_shape.insert(1, m)
                 elif flatten.lower() == 'never':
                     self.data_dim_keys.append(key)
-                    data_shape.append(m)
+                    data_shape.insert(1, m)
             except KeyError:
                 pass
             except ValueError:


### PR DESCRIPTION
Correct a bug where the bursts were getting reshaped incorrectly. Prior to this the attenuator setting dimension m was being added at the end of data_shape, but this meant that when you reshape the flat array of burst data back into a 2- or 3d array it was ending up with the data in the wrong place (m bursts would  appear in the first 40001 samples all concatenated, but only every mth sample would be present).